### PR TITLE
Update the upload_part_copy test and delete intermediate parts for GCP 

### DIFF
--- a/s3-proxy/justfile
+++ b/s3-proxy/justfile
@@ -38,8 +38,8 @@ run-registry:
 
 install-local-s3:
   cargo install --force \
-    --git https://github.com/Nugine/s3s.git \
-    --rev 210616177344d295f987c594ce6012f76e4597eb \
+    --git https://github.com/lynnliu030/s3s.git \
+    --rev 54b9bd91c1498e917703c092e984249b1ff0423b \
     --bin s3s-fs \
     --features="binary" \
     s3s-fs

--- a/s3-proxy/src/client_impls/gcp.rs
+++ b/s3-proxy/src/client_impls/gcp.rs
@@ -322,6 +322,7 @@ impl ObjectStoreClient for GCPObjectStoreClient {
     ) -> S3Result<S3Response<CompleteMultipartUploadOutput>> {
         let req = req.input;
         let bucket = req.bucket;
+        let bucket_clone = bucket.clone();
         let object = req.key;
         let upload_id = req.upload_id;
 
@@ -343,9 +344,9 @@ impl ObjectStoreClient for GCPObjectStoreClient {
             })
             .collect();
 
+        let mut to_delete: Vec<SourceObjects> = parts.clone();
+
         if parts.len() > 32 {
-            // GCS only supports compsing 1-32 objects. In this case,
-            // we need to compose multiple times.
             let mut composed_parts = Vec::new();
             let mut compose_batch_id: usize = 0;
             while parts.len() > 32 {
@@ -356,7 +357,7 @@ impl ObjectStoreClient for GCPObjectStoreClient {
                     .client
                     .compose_object(&ComposeObjectRequest {
                         bucket: bucket.clone(),
-                        destination_object: composed_object,
+                        destination_object: composed_object.clone(),
                         composing_targets: ComposingTargets {
                             source_objects: parts.drain(..32).collect(),
                             ..Default::default()
@@ -368,6 +369,11 @@ impl ObjectStoreClient for GCPObjectStoreClient {
 
                 composed_parts.push(SourceObjects {
                     name: res.name,
+                    ..Default::default()
+                });
+
+                to_delete.push(SourceObjects {
+                    name: composed_object,
                     ..Default::default()
                 });
 
@@ -389,7 +395,17 @@ impl ObjectStoreClient for GCPObjectStoreClient {
             .await
             .unwrap();
 
-        // TODO: delete parts, high priority
+        // Delete the intermediate parts and objects
+        for obj in to_delete {
+            self.client
+                .delete_object(&DeleteObjectRequest {
+                    bucket: bucket_clone.clone(),
+                    object: obj.name,
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+        }
 
         Ok(S3Response::new(CompleteMultipartUploadOutput {
             e_tag: Some(res.etag),

--- a/s3-proxy/src/client_impls/gcp.rs
+++ b/s3-proxy/src/client_impls/gcp.rs
@@ -396,6 +396,7 @@ impl ObjectStoreClient for GCPObjectStoreClient {
             .unwrap();
 
         // Delete the intermediate parts and objects
+        // TODO: consider sending a batch request or parallelize it. 
         for obj in to_delete {
             self.client
                 .delete_object(&DeleteObjectRequest {

--- a/s3-proxy/src/skyproxy.rs
+++ b/s3-proxy/src/skyproxy.rs
@@ -1872,7 +1872,7 @@ mod tests {
 
     #[tokio::test]
     #[serial]
-    #[ignore = "UploadPartCopy is not implemented in the emulator."]
+    // #[ignore = "UploadPartCopy is not implemented in the emulator."]
     async fn test_multipart_flow() {
         let proxy = SkyProxy::new(REGIONS.clone(), CLIENT_FROM_REGION.clone(), true).await;
 

--- a/s3-proxy/src/skyproxy.rs
+++ b/s3-proxy/src/skyproxy.rs
@@ -1872,7 +1872,6 @@ mod tests {
 
     #[tokio::test]
     #[serial]
-    // #[ignore = "UploadPartCopy is not implemented in the emulator."]
     async fn test_multipart_flow() {
         let proxy = SkyProxy::new(REGIONS.clone(), CLIENT_FROM_REGION.clone(), true).await;
 


### PR DESCRIPTION
Implement `upload_part_copy` in s3s-fs [here](https://github.com/lynnliu030/s3s/commit/54b9bd91c1498e917703c092e984249b1ff0423b), re-enable the test. Also delete intermediate parts for GCP multipart uploads.

TODO: add tests for range copy for upload_part_copy, check here https://github.com/skyplane-project/skystore/pull/48