### PR TITLE
provide server address via conf or cli

### DIFF
--- a/s3-proxy/src/main.rs
+++ b/s3-proxy/src/main.rs
@@ -61,6 +61,9 @@ async fn main() {
         .map(|s| s.parse::<bool>().unwrap())
         .unwrap_or(true);
 
+    let server_addr: String =
+        env::var("SERVER_ADDR").expect("SERVER ADDRESS is missing");
+
     let policy: String = env::var("POLICY").expect("POLICY for placement must be set");
 
     let proxy = SkyProxy::new(
@@ -70,6 +73,7 @@ async fn main() {
         local_server,
         policy,
         skystore_bucket_prefix,
+        server_addr,
     )
     .await;
 

--- a/s3-proxy/src/main.rs
+++ b/s3-proxy/src/main.rs
@@ -61,8 +61,7 @@ async fn main() {
         .map(|s| s.parse::<bool>().unwrap())
         .unwrap_or(true);
 
-    let server_addr: String =
-        env::var("SERVER_ADDR").expect("SERVER ADDRESS is missing");
+    let server_addr: String = env::var("SERVER_ADDR").expect("SERVER ADDRESS is missing");
 
     let policy: String = env::var("POLICY").expect("POLICY for placement must be set");
 

--- a/s3-proxy/src/skyproxy.rs
+++ b/s3-proxy/src/skyproxy.rs
@@ -22,6 +22,7 @@ pub struct SkyProxy {
     pub client_from_region: String,
     pub policy: String,
     pub skystore_bucket_prefix: String,
+    pub server_addr: String,
 }
 
 impl SkyProxy {
@@ -32,6 +33,7 @@ impl SkyProxy {
         local_server: bool,
         policy: String,
         skystore_bucket_prefix: String,
+        server_addr: String,
     ) -> Self {
         let mut store_clients = HashMap::new();
 
@@ -147,7 +149,8 @@ impl SkyProxy {
                 "http://127.0.0.1:3000".to_string()
             } else {
                 // NOTE: ip address set to be the remote store-server addr
-                "http://54.183.123.82:3000".to_string()
+                //"http://54.183.123.82:3000".to_string()
+                format!("http://{}:3000", server_addr).to_string()
             },
             ..Default::default()
         };
@@ -162,6 +165,7 @@ impl SkyProxy {
             client_from_region,
             policy,
             skystore_bucket_prefix,
+            server_addr,
         }
     }
 }
@@ -174,6 +178,7 @@ impl Clone for SkyProxy {
             client_from_region: self.client_from_region.clone(),
             skystore_bucket_prefix: self.skystore_bucket_prefix.clone(),
             policy: self.policy.clone(),
+            server_addr: self.server_addr.clone(),
         }
     }
 }
@@ -271,7 +276,6 @@ impl S3 for SkyProxy {
         )
         .await
         .unwrap();
-
         // Create bucket in actual storages
         let mut tasks = tokio::task::JoinSet::new();
         let locators = create_bucket_resp.locators;

--- a/s3-proxy/src/skyproxy_test.rs
+++ b/s3-proxy/src/skyproxy_test.rs
@@ -33,6 +33,7 @@ mod tests {
             true,
             "push".to_string(),
             "skystore".to_string(),
+            "localhost"
         )
         .await
     }

--- a/s3-proxy/src/skyproxy_test.rs
+++ b/s3-proxy/src/skyproxy_test.rs
@@ -33,7 +33,7 @@ mod tests {
             true,
             "push".to_string(),
             "skystore".to_string(),
-            "localhost"
+            "localhost",
         )
         .await
     }

--- a/s3-proxy/src/skyproxy_test.rs
+++ b/s3-proxy/src/skyproxy_test.rs
@@ -33,7 +33,7 @@ mod tests {
             true,
             "push".to_string(),
             "skystore".to_string(),
-            "localhost",
+            "localhost".to_string(),
         )
         .await
     }

--- a/skystore_cli.py
+++ b/skystore_cli.py
@@ -133,7 +133,7 @@ def register(
     else:
         # backward compatible
         # server_addr = "SERVER IP"
-        pass;
+        pass
 
     try:
         with open(register_config, "r") as f:

--- a/skystore_cli.py
+++ b/skystore_cli.py
@@ -43,6 +43,11 @@ def init(
     policy: Policy = typer.Option(
         Policy.write_local, "--policy", help="Policy to use for data placement"
     ),
+
+    server_addr: str = typer.Option(
+        "localhost", "--server_addr", help="IP address of the SkyStore metadata server"
+    ),
+
 ):
     with open(config_file, "r") as f:
         config = json.load(f)
@@ -65,6 +70,7 @@ def init(
         "LOCAL_SERVER": str(start_server).lower(),
         "POLICY": policy,
         "SKYSTORE_BUCKET_PREFIX": skystore_bucket_prefix,
+        "SERVER_ADDR": server_addr,
     }
     env = {k: v for k, v in env.items() if v is not None}
 
@@ -116,13 +122,18 @@ def register(
     local_test: bool = typer.Option(
         False, "--local", help="Whether it is a local test or not"
     ),
+    server_addr: str = typer.Option(
+        "localhost", "--server_addr", help="IP address of the SkyStore metadata server"
+    ),
+
 ):
     # read from LOCAL_SERVER environmental variable instead
     if local_test:
         server_addr = "localhost"
     else:
-        # NOTE: ip address set to be the remote store-server addr
-        server_addr = "54.183.123.82"
+        # backward compatible
+        # server_addr = "SERVER IP"
+        pass;
 
     try:
         with open(register_config, "r") as f:

--- a/store-server/operations/object_operations.py
+++ b/store-server/operations/object_operations.py
@@ -704,18 +704,20 @@ async def continue_upload(
             region=locator.region,
             key=locator.key,
             multipart_upload_id=locator.multipart_upload_id,
-            parts=[
-                ContinueUploadPhysicalPart(
-                    part_number=part.part_number,
-                    etag=part.etag,
-                )
-                for part in locator.multipart_upload_parts
-            ]
-            if request.do_list_parts
-            else None,
-            copy_src_bucket=copy_src_buckets[i]
-            if request.copy_src_bucket is not None
-            else None,
+            parts=(
+                [
+                    ContinueUploadPhysicalPart(
+                        part_number=part.part_number,
+                        etag=part.etag,
+                    )
+                    for part in locator.multipart_upload_parts
+                ]
+                if request.do_list_parts
+                else None
+            ),
+            copy_src_bucket=(
+                copy_src_buckets[i] if request.copy_src_bucket is not None else None
+            ),
             copy_src_key=copy_src_keys[i] if request.copy_src_key is not None else None,
         )
         for i, locator in enumerate(locators)

--- a/store-server/operations/policy/utils/helper.py
+++ b/store-server/operations/policy/utils/helper.py
@@ -125,9 +125,11 @@ def make_nx_graph(
             ingress_limit = (
                 aws_instance_throughput_limit[1]
                 if node.startswith("aws")
-                else gcp_instance_throughput_limit[1]
-                if node.startswith("gcp")
-                else azure_instance_throughput_limit[1]
+                else (
+                    gcp_instance_throughput_limit[1]
+                    if node.startswith("gcp")
+                    else azure_instance_throughput_limit[1]
+                )
             )
             G.add_edge(
                 node, node, cost=0, throughput=num_vms * ingress_limit, latency=40


### PR DESCRIPTION
Currently the way to provide server IP is by manually edit skyproxy.rs and skystore_cli.py and re build the code.

This PR leaves the existing approach as, but also add an option to provide server IP via CLI

`skystore init --config myconf --server_addr=<IP address or localhost>`

or via conf file, as example


     {
      "init_regions": [
        "aws:eu-central-1"
       ],
      "client_from_region": "aws:eu-central-1",
      "skystore_bucket_prefix": "skystore",
      "policy": "write_local",
      "server_addr": "IP of the SkyStore Server"
     }


