### PR TITLE
FIx bugs in Postgres user configuration and ip config.

### DIFF
--- a/s3-proxy/src/skyproxy_test.rs
+++ b/s3-proxy/src/skyproxy_test.rs
@@ -28,7 +28,7 @@ mod tests {
             "physical_multipart_upload_parts".to_string(),
             "metrics".to_string()
         ];
-        static ref USER: String = "skystore".to_string();
+        static ref USER: String = "ubuntu".to_string();
         static ref DABNAME: String = "skystore".to_string();
     }
 

--- a/s3-proxy/test/register_config3.json
+++ b/s3-proxy/test/register_config3.json
@@ -3,11 +3,17 @@
     "config": {
         "physical_locations": [
             {
-                "name": "aws:us-west-1",
+                "name": "aws:eu-south-1",
                 "cloud": "aws",
-                "region": "us-west-1",
-                "bucket": "my-sky-bucket-1",
+                "region": "eu-south-1",
+                "bucket": "skystore-eu-south-1",
                 "is_primary": true
+            },
+            {
+                "name": "aws:eu-nouth-1",
+                "cloud": "aws",
+                "region": "eu-nouth-1",
+                "bucket": "skystore-eu-nouth-1"
             }
         ]
     },

--- a/skystore_cli.py
+++ b/skystore_cli.py
@@ -77,6 +77,10 @@ def init(
         if "skystore_bucket_prefix" in config
         else "skystore"
     )
+    
+    if "server_addr" in config:
+        server_addr = config["server_addr"]
+    
     env = {
         **os.environ,
         "INIT_REGIONS": init_regions_str,

--- a/skystore_cli.py
+++ b/skystore_cli.py
@@ -77,10 +77,10 @@ def init(
         if "skystore_bucket_prefix" in config
         else "skystore"
     )
-    
+
     if "server_addr" in config:
         server_addr = config["server_addr"]
-    
+
     env = {
         **os.environ,
         "INIT_REGIONS": init_regions_str,

--- a/store-server/experiment/client.py
+++ b/store-server/experiment/client.py
@@ -158,7 +158,7 @@ def create_instance(
             "skystore_bucket_prefix": "skystore",
             "put_policy": "replicate_all",
             "get_policy": "closest",
-            "server_addr": "localhost", # TODO: change this to the actual server address
+            "server_addr": "localhost",  # NOTE: change this to the actual server address
         }
         config_file_path = f"/tmp/init_config_{server.region_tag}.json"
         check_stderr(

--- a/store-server/experiment/client.py
+++ b/store-server/experiment/client.py
@@ -188,7 +188,7 @@ def create_instance(
         )
 
         # Set up other stuff
-        url = "https://github.com/shaopu1225/skystore.git"
+        url = "https://github.com/skyplane-project/skystore"
         clone_cmd = f"git clone {url}; cd skystore; git switch experiments; "
         cmd1 = f"sudo apt remove python3-apt -y; sudo apt autoremove -y; \
                 sudo apt autoclean; sudo apt install python3-apt -y; sudo apt-get update; \

--- a/store-server/experiment/client.py
+++ b/store-server/experiment/client.py
@@ -189,7 +189,7 @@ def create_instance(
 
         # Set up other stuff
         url = "https://github.com/shaopu1225/skystore.git"
-        clone_cmd = f"git clone {url}; cd skystore; git switch experiment; "
+        clone_cmd = f"git clone {url}; cd skystore; git switch experiments; "
         cmd1 = f"sudo apt remove python3-apt -y; sudo apt autoremove -y; \
                 sudo apt autoclean; sudo apt install python3-apt -y; sudo apt-get update; \
                 sudo apt install python3.9 -y; sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1; \

--- a/store-server/experiment/client.py
+++ b/store-server/experiment/client.py
@@ -158,6 +158,7 @@ def create_instance(
             "skystore_bucket_prefix": "skystore",
             "put_policy": "replicate_all",
             "get_policy": "closest",
+            "server_addr": "localhost", # TODO: change this to the actual server address
         }
         config_file_path = f"/tmp/init_config_{server.region_tag}.json"
         check_stderr(

--- a/store-server/experiment/client.py
+++ b/store-server/experiment/client.py
@@ -188,7 +188,7 @@ def create_instance(
         )
 
         # Set up other stuff
-        url = "https://github.com/skyplane-project/skystore"
+        url = "https://github.com/skyplane-project/skystore.git"
         clone_cmd = f"git clone {url}; cd skystore; git switch experiments; "
         cmd1 = f"sudo apt remove python3-apt -y; sudo apt autoremove -y; \
                 sudo apt autoclean; sudo apt install python3-apt -y; sudo apt-get update; \

--- a/store-server/experiment/host.py
+++ b/store-server/experiment/host.py
@@ -184,7 +184,7 @@ def create_instance(
         # install cargo
         server.run_command(
             f"curl https://sh.rustup.rs -sSf | sh -s -- -y; source $HOME/.cargo/env; \
-            git clone https://github.com/shaopu1225/skystore.git; cd skystore/store-server; git switch experiments; \
+            git clone https://github.com/skyplane-project/skystore; cd skystore/store-server; git switch experiments; \
             sudo apt-get install libpq-dev -y; sudo apt-get install python3.9-dev -y; pip3 install -r requirements.txt; /home/ubuntu/.cargo/bin/cargo install just --force; \
             sudo -u postgres psql -c \"CREATE ROLE ubuntu WITH LOGIN PASSWORD 'skystore';ALTER ROLE ubuntu WITH SUPERUSER\"; \
             export INIT_REGIONS={','.join(init_regions_list)}; \

--- a/store-server/experiment/host.py
+++ b/store-server/experiment/host.py
@@ -184,7 +184,7 @@ def create_instance(
         # install cargo
         server.run_command(
             f"curl https://sh.rustup.rs -sSf | sh -s -- -y; source $HOME/.cargo/env; \
-            git clone https://github.com/skyplane-project/skystore; cd skystore/store-server; git switch experiments; \
+            git clone https://github.com/skyplane-project/skystore.git; cd skystore/store-server; git switch experiments; \
             sudo apt-get install libpq-dev -y; sudo apt-get install python3.9-dev -y; pip3 install -r requirements.txt; /home/ubuntu/.cargo/bin/cargo install just --force; \
             sudo -u postgres psql -c \"CREATE ROLE ubuntu WITH LOGIN PASSWORD 'skystore';ALTER ROLE ubuntu WITH SUPERUSER\"; \
             export INIT_REGIONS={','.join(init_regions_list)}; \

--- a/store-server/experiment/host.py
+++ b/store-server/experiment/host.py
@@ -184,7 +184,7 @@ def create_instance(
         # install cargo
         server.run_command(
             f"curl https://sh.rustup.rs -sSf | sh -s -- -y; source $HOME/.cargo/env; \
-            git clone https://github.com/shaopu1225/skystore.git; cd skystore/store-server; git switch experiment; \
+            git clone https://github.com/shaopu1225/skystore.git; cd skystore/store-server; git switch experiments; \
             sudo apt-get install libpq-dev -y; sudo apt-get install python3.9-dev -y; pip3 install -r requirements.txt; /home/ubuntu/.cargo/bin/cargo install just --force; \
             sudo -u postgres psql -c \"CREATE ROLE ubuntu WITH LOGIN PASSWORD 'skystore';ALTER ROLE ubuntu WITH SUPERUSER\"; \
             export INIT_REGIONS={','.join(init_regions_list)}; \

--- a/store-server/experiment/host.py
+++ b/store-server/experiment/host.py
@@ -59,16 +59,8 @@ def create_instance(
     # validate arguments
     aws_region_list = ["us-west-1"]
     init_regions_list = [
-        "aws:ap-south-1",
-        "aws:sa-east-1",
-        "aws:eu-south-2",
-        "aws:ap-southeast-1",
-        "aws:eu-north-1",
-        "aws:ap-northeast-1",
-        "aws:ap-southeast-3",
-        "aws:me-south-1",
-        "aws:us-east-2",
-        "aws:eu-west-3",
+        "aws:eu-south-1",
+        "aws:eu-nouth-1",
     ]
     skystore_bucket_prefix = "skystore"
 
@@ -194,7 +186,7 @@ def create_instance(
             f"curl https://sh.rustup.rs -sSf | sh -s -- -y; source $HOME/.cargo/env; \
             git clone https://github.com/shaopu1225/skystore.git; cd skystore/store-server; git switch experiment; \
             sudo apt-get install libpq-dev -y; sudo apt-get install python3.9-dev -y; pip3 install -r requirements.txt; /home/ubuntu/.cargo/bin/cargo install just --force; \
-            sudo -u postgres psql -c \"ALTER USER postgres PASSWORD 'skystore'\"; \
+            sudo -u postgres psql -c \"CREATE ROLE ubuntu WITH LOGIN PASSWORD 'skystore';ALTER ROLE ubuntu WITH SUPERUSER\"; \
             export INIT_REGIONS={','.join(init_regions_list)}; \
             export SKYSTORE_BUCKET_PREFIX={skystore_bucket_prefix}; \
             nohup python3.9 -m uvicorn app:app --host 0.0.0.0 --port 3000 > control_plane_output 2>&1 &"

--- a/store-server/operations/utils/db.py
+++ b/store-server/operations/utils/db.py
@@ -93,7 +93,7 @@ async def create_database(
 
 # Define the name of the database you want to create
 database_name = "skystore"
-user = "postgres"
+user = "ubuntu"
 password = "skystore"
 
 


### PR DESCRIPTION
- Set default username to 'ubuntu' as required by the [peer authentication](https://stackoverflow.com/questions/18664074/getting-error-peer-authentication-failed-for-user-postgres-when-trying-to-ge) of Postgres.  
- When we have added `server_addr` in the init_config file, we will use this first rather than the command line parameters, preventing users from using default cmd server_addr parameter `localhost` unawarely even they set the ip addr in config file.